### PR TITLE
TFT_RST Moved So Periodic TFT Screen Reset Can Be Enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,14 +24,14 @@ Color touchscreen https://www.pjrc.com/store/display_ili9341_touch.html
    |-----|-----|-----|-----|				
    | GND | gnd | Vin | common with Vin(screen) |
    | | 0 | gnd |  |
-   | | 1 | 3.3V | RESET (screen) |   
+   | | 1 | 3.3V |  |   
    | | 2 | 23 | MCLK (audio) |
    | | 3 | 22 | LED  (to screen via a series 100 ohm resistor)|
    | | 4 | 21 | BCLK (audio) |
    | D/C (screen)	| 5	| 20 | LRCLK (audio)|
 |MEMCS (audio)|	6|	19|	SCL (audio)|
 |DIN (audio) |7|18|SDA (audio)|
-|DOUT (audio)|8|17||
+|DOUT (audio)|8|17|RESET (screen)|
 |T_CS (screen)|9|  16|T_IRQ (screen) Not connected|
 |SDCS (audio)|10|15|VOL (audio)|
 |MOSI|11|14|CS (screen)|
@@ -46,7 +46,7 @@ Color touchscreen https://www.pjrc.com/store/display_ili9341_touch.html
 |1 |VCC| common with Vin |				
  |2|GND| common with GND |	
  |3|CS|14|
- |4|RESET	|24 (3.3v)|			
+ |4|RESET	|17|			
  |5|D/C|	5|			
  |6|SDI (MOSI)|	11|			
  |7|SCK|13|


### PR DESCRIPTION
Here's a summary of the code update/changes:

Code added to periodically reset the TFT display.
A summary of the code changes are:

// PR:
#define TFT_RST	    17    // connect to I/O #17 (or change to available digital/analog I/O)
// ---

// PR:
// comment out the following if screen locks/freezes isn't an issue on your system
#define TFT_RESET_STROBE_TIME_OUT 10		// 1 is 1 min, 2 is 2 min, ... 10 is 10 min.

#if defined(TFT_RESET_STROBE_TIME_OUT)
#define TFT_RESET_STROBE
#endif
// opt:
#define SERIAL_COUNTER_TIME_OUT 5000    // so serial port doesn't hang the board
// ---

// PR:
#ifdef TFT_RESET_STROBE
Metro minute_timer = Metro(TFT_RESET_STROBE_TIME_OUT * 60000);
#endif
// ---

// PR:  (optional - is this an issue with Teensy like the Arduino boards??)
#if 1
  // in case serial port isn't connected so we don't hang the program:
	do {
		counter_main++;

	} while ( !Serial && ( counter_main < SERIAL_COUNTER_TIME_OUT) );
#endif
// ---	
// PR:  Note - in tft.begin() - TFT_RST handled as digital pin vs. analog. 
// PR:  
#ifdef TFT_RESET_STROBE
  if ( TFT_RESET_STROBE_TIME_OUT > 0 ) {        // more robust check here needed possibly?
  if ( minute_timer.check() == 1 ) {
//	  pinMode( TFT_RST, OUTPUT);
	  analogWrite(TFT_RST, 1023);		// tft.begin() _rst - using digital vs. analog write.
	  delay(5);
	  analogWrite(TFT_RST, 0);
	  delay(20);
	  analogWrite(TFT_RST, 1023);
	  delay(150);
	  Serial.printf("\r\n:SCREEN RESET:\r\n");  // just for debug - screen will freeze momentarily then resume
  }
 }
#endif
// ---

Note, in the TFT library - the digital vs. analog writes could be an issue with the display we're using:

// toggle RST low to reset
	if (_rst < 255) {
		pinMode(_rst, OUTPUT);
		digitalWrite(_rst, HIGH);
		delay(5);
		digitalWrite(_rst, LOW);
		delay(20);
		digitalWrite(_rst, HIGH);
		delay(150);
	}

Regards,
jwestmoreland


